### PR TITLE
[IMP] Add Discount on each line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*/__pycache__/

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -20,6 +20,11 @@
         "views/product_supplierinfo_view.xml",
         "views/res_partner_view.xml",
     ],
+    'assets': {
+        'web.assets_backend': [
+            'sale/static/src/js/product_discount_field.js',
+            'sale/static/src/xml/**/*',
+    ]},
     "license": "AGPL-3",
     "installable": True,
     "images": ["images/purchase_discount.png"],

--- a/static/src/js/product_discount_field.js
+++ b/static/src/js/product_discount_field.js
@@ -1,0 +1,58 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { FloatField } from "@web/views/fields/float/float_field";
+import { _lt } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+/**
+ * Dialog called if user changes a value in the purchase order line.
+ * The wizard will open only if
+ *  (1) Purchase order line is 3 or more
+ *  (2) First purchase order line is changed
+ *  (3) value is the same in all other purchase order line
+ */
+
+export class ProductDiscountField extends FloatField {
+  setup() {
+    super.setup();
+    this.dialogService = useService("dialog");
+  }
+
+  onChange(ev) {
+    const x2mList = this.props.record.model.root.data.order_line;
+    const orderLines = x2mList.records.filter(
+      (line) => !line.data.display_type
+    );
+
+    if (orderLines.length < 3) {
+      return;
+    }
+
+    const isFirstOrderLine =
+      this.props.record.data.id === orderLines[0].data.id;
+    if (isFirstOrderLine) {
+      this.dialogService.add(ConfirmationDialog, {
+        body: _lt("Do you want to apply this value to all lines ?"),
+        confirm: () => {
+          const commands = orderLines.slice(1).map((line) => {
+            return {
+              operation: "UPDATE",
+              record: line,
+              data: { ["discount"]: this.props.value },
+            };
+          });
+
+          x2mList.applyCommands("order_line", commands);
+        },
+      });
+    }
+  }
+}
+
+ProductDiscountField.components = { ConfirmationDialog };
+ProductDiscountField.template = "purchase.ProductDiscountField";
+ProductDiscountField.displayName = _lt("Disc.%");
+
+registry.category("fields").add("sol_discount", ProductDiscountField);

--- a/static/src/xml/product_discount_field.xml
+++ b/static/src/xml/product_discount_field.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="purchase.ProductDiscountField" t-inherit="web.FloatField" t-inherit-mode="primary" owl="1">
+        <xpath expr="//input" position="attributes">
+            <attribute name="t-on-change">onChange</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/views/purchase_discount_view.xml
+++ b/views/purchase_discount_view.xml
@@ -32,6 +32,7 @@
                 <field
                     name="discount"
                     attrs="{'readonly': [('qty_invoiced', '!=', 0)]}"
+                    groups="product.group_discount_per_so_line" optional="show" widget="sol_discount"
                 />
             </xpath>
             <xpath


### PR DESCRIPTION
### Rationale ⏮️ 
A new module was added recently to add a discount on PO.

But we have to manually add them on each line. For some PO, we have dozens of lines. It's time-consuming to add them on each line.

### Specification ♻️ :
Based on the sales module which allow us to add the discount on each line, make the same mechanism on the PO.

[Video](https://drive.google.com/file/d/1GpdXQb1s9aJ3HTduMM0akMBfVOqZLztt/view?usp=sharing)